### PR TITLE
Add requested value to not found message

### DIFF
--- a/tests_wtf.py
+++ b/tests_wtf.py
@@ -42,4 +42,5 @@ def test_no_slack_token(client):
 def test_not_found(client):
     data = {'text': '13231312334','token': os.getenv('SLACK_TOKEN')}
     r = client.post(ROUTE, data=data)
-    assert b'Not found!' in r.data
+    assert b'not found!' in r.data
+    assert b'13231312334' in r.data

--- a/wtf.py
+++ b/wtf.py
@@ -51,8 +51,8 @@ def slack():
 
     except KeyError:
         response = """
-        Not found! Acronyms may be added at
+        Entry for '{}' not found! Acronyms may be added at
         https://github.com/department-of-veterans-affairs/acronyms
-        """
+        """.format(req['text'])
 
     return make_response(response)


### PR DESCRIPTION
## Story

> As a user, I'd like to see the term I requested that results in a "not found" to confirm that I requested the right term and did not fat finger it.

## New behavior

`curl -X POST http://127.0.0.1:5000/slack -d "text=foo&token=foo"` returns:

```
Entry for 'foo' not found! Acronyms may be added at https://github.com/department-of-veterans-affairs/acronyms
```

## Testing

- Unit tests updated.
- Tested locally.