### PR TITLE
allow multiple tokens for multiple slacks

### DIFF
--- a/.cfignore
+++ b/.cfignore
@@ -3,3 +3,4 @@ venv
 vars.yml
 .pytest_cache
 __pycache__
+.coverage

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ venv
 vars.yml
 .pytest_cache
 __pycache__
+.coverage

--- a/config.py
+++ b/config.py
@@ -1,4 +1,4 @@
 from os import getenv
 
-SLACK_TOKEN = getenv('SLACK_TOKEN')
+SLACK_TOKENS = [token.strip() for token in getenv('SLACK_TOKENS').split(',')]
 DATA_URL = getenv('DATA_URL')

--- a/manifest.yml
+++ b/manifest.yml
@@ -7,5 +7,5 @@ applications:
   stack: cflinuxfs3
   # cf push --vars-file vars.yml ...
   env:
-      SLACK_TOKEN: ((SLACK_TOKEN))
+      SLACK_TOKENS: ((SLACK_TOKENS))
       DATA_URL: ((DATA_URL))

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ urllib3==1.24.2
 Werkzeug==0.15.2
 gunicorn==19.9.0
 pytest==5.0.1
+pytest-cov==2.8.1

--- a/tests_wtf.py
+++ b/tests_wtf.py
@@ -1,10 +1,16 @@
-import os, json
-import pytest
-from wtf import APP
-from config import SLACK_TOKENS
+import os
 
+# Update/add env variables for this subprocess to test multiple Slack tokens.
+# Must be done before wtf.APP and config.SLACK_TOKENS are imported.
+os.environ['SLACK_TOKENS'] = 'test_token0, test_token1, test_token2'
+
+import json
+import pytest
+from config import SLACK_TOKENS
+from wtf import APP
+
+TEST_TOKEN = SLACK_TOKENS[2]
 ROUTE = '/slack'
-TEST_TOKEN = SLACK_TOKENS[0]
 
 @pytest.fixture
 def client():
@@ -15,6 +21,11 @@ def client():
 def test_env_vars_present():
     for var in ['SLACK_TOKENS', 'DATA_URL']:
         assert os.getenv(var) != None
+
+def test_different_slack_token(client):
+    data = {'text': 'vba','token': SLACK_TOKENS[1]}
+    r = client.post(ROUTE, data=data)
+    assert r.status_code != 401
 
 def test_good_payload(client):
     data = {'text': 'vba','token': TEST_TOKEN}

--- a/tests_wtf.py
+++ b/tests_wtf.py
@@ -1,8 +1,10 @@
 import os, json
 import pytest
 from wtf import APP
+from config import SLACK_TOKENS
 
 ROUTE = '/slack'
+TEST_TOKEN = SLACK_TOKENS[0]
 
 @pytest.fixture
 def client():
@@ -11,36 +13,36 @@ def client():
     yield client
 
 def test_env_vars_present():
-    for var in ['SLACK_TOKEN', 'DATA_URL']:
+    for var in ['SLACK_TOKENS', 'DATA_URL']:
         assert os.getenv(var) != None
 
 def test_good_payload(client):
-    data = {'text': 'vba','token': os.getenv('SLACK_TOKEN')}
+    data = {'text': 'vba','token': TEST_TOKEN}
     r = client.post(ROUTE, data=data)
     assert b'Veterans Benefits Administration' in r.data
 
 def test_multi_def_payload(client):
-    data = {'text': 'aaa','token': os.getenv('SLACK_TOKEN')}
+    data = {'text': 'aaa','token': TEST_TOKEN}
     r = client.post(ROUTE, data=data)
     assert b'Abdominal Aortic Aneurysm; or Area Agencies on Aging;' in r.data
 
 def test_comma_in_def(client):
-    data = {'text': 'acre','token': os.getenv('SLACK_TOKEN')}
+    data = {'text': 'acre','token': TEST_TOKEN}
     r = client.post(ROUTE, data=data)
     assert b'A measure of land 43,560 sq. ft.' in r.data
 
 def test_bad_payload(client):
-    data = {'foo': 'bar', 'token': os.getenv('SLACK_TOKEN')}
+    data = {'foo': 'bar', 'token': TEST_TOKEN}
     r = client.post(ROUTE, data=data)
     assert b'Improper request' in r.data
 
 def test_no_slack_token(client):
-    data = {'text': 'vba','token': '13231312334'}
+    data = {'text': 'vba','token': ' foobar'}
     r = client.post(ROUTE, data=data)
     assert b'Not authorized' in r.data
 
 def test_not_found(client):
-    data = {'text': '13231312334','token': os.getenv('SLACK_TOKEN')}
+    data = {'text': '13231312334','token': TEST_TOKEN}
     r = client.post(ROUTE, data=data)
     assert b'not found!' in r.data
     assert b'13231312334' in r.data

--- a/wtf.py
+++ b/wtf.py
@@ -1,8 +1,7 @@
-import os
 import csv
 import requests
 from flask import Flask, make_response, request
-from config import SLACK_TOKEN, DATA_URL
+from config import SLACK_TOKENS, DATA_URL
 
 APP = Flask(__name__)
 
@@ -14,7 +13,7 @@ def slack():
     if not all(k in req.keys() for k in ['text', 'token']):
         return make_response('Improper request.', 400)
 
-    if not req['token'] == SLACK_TOKEN:
+    if req['token'] not in SLACK_TOKENS:
         return make_response('Not authorized', 401)
 
     raw = requests.get(DATA_URL)

--- a/wtf.py
+++ b/wtf.py
@@ -1,4 +1,5 @@
 import csv
+import http
 import requests
 from flask import Flask, make_response, request
 from config import SLACK_TOKENS, DATA_URL
@@ -11,10 +12,10 @@ def slack():
     req = dict(request.form)
 
     if not all(k in req.keys() for k in ['text', 'token']):
-        return make_response('Improper request.', 400)
+        return make_response('Improper request.', http.HTTPStatus.BAD_REQUEST)
 
     if req['token'] not in SLACK_TOKENS:
-        return make_response('Not authorized', 401)
+        return make_response('Not authorized', http.HTTPStatus.UNAUTHORIZED)
 
     raw = requests.get(DATA_URL)
 


### PR DESCRIPTION
Allows multiple Slack tokens to be accepted and, hence, multiple Slack teams to share an instance of the bot.